### PR TITLE
[FIX] stock_internal_use_of_products: set no company for general internal use sequence to avoid null name in V12

### DIFF
--- a/stock_internal_use_of_products/data/ir_sequence.xml
+++ b/stock_internal_use_of_products/data/ir_sequence.xml
@@ -12,6 +12,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="code">internal.use</field>
             <field name="prefix">IU/%(year)s/</field>
             <field name="padding">5</field>
+            <field name="company_id" eval="False"/>
         </record>
     </data>
 </openerp>


### PR DESCRIPTION
in V12, sequence are correctly protected by company_id.
if a company_id is defined, that is the case if no company key is provided, so the sequence will not be accessible for other companies.

apps/deck/#/board/144/card/1364

