### PR TITLE
 [FIX] stock_picking_quick_quantity_done : make action_confirm working with many elements

### DIFF
--- a/stock_picking_quick_quantity_done/models/sale_order.py
+++ b/stock_picking_quick_quantity_done/models/sale_order.py
@@ -13,6 +13,6 @@ class SaleOrder(models.Model):
         """After Confirm, force stock.move.line to be full, ready to be
         validated"""
         super().action_confirm()
-        for picking in self.picking_ids:
+        for picking in self.mapped("picking_ids"):
             picking.quick_quantities_done()
         return True


### PR DESCRIPTION
yop. 

mini correctif. self.picking_ids fonctionne seulement pour un élément dans self. si y'a plusieurs éléments, il faut faire self.mappe("").

CC : @quentinDupont 