### PR TITLE
 [IMP] stock_internal_use_of_products : add tree view for internal.use.line model

### DIFF
--- a/stock_internal_use_of_products/__manifest__.py
+++ b/stock_internal_use_of_products/__manifest__.py
@@ -19,6 +19,7 @@
         "security/ir_rule.xml",
         "data/ir_sequence.xml",
         "views/view_internal_use.xml",
+        "views/view_internal_use_line.xml",
         "views/view_internal_use_case.xml",
         "views/view_internal_use_mass_generate_wizard.xml",
     ],

--- a/stock_internal_use_of_products/i18n/fr.po
+++ b/stock_internal_use_of_products/i18n/fr.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 12.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-12-18 20:34+0000\n"
-"PO-Revision-Date: 2020-12-18 20:34+0000\n"
+"POT-Creation-Date: 2021-06-18 12:39+0000\n"
+"PO-Revision-Date: 2021-06-18 12:39+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use_case.py:52
+#: code:addons/stock_internal_use_of_products/models/internal_use_case.py:66
 #, python-format
 msgid "%s (copy)"
 msgstr "%s (copie)"
@@ -58,6 +58,7 @@ msgstr "Annuler"
 
 #. module: stock_internal_use_of_products
 #: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use__internal_use_case_id
+#: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use_line__internal_use_case_id
 #: model_terms:ir.ui.view,arch_db:stock_internal_use_of_products.view_internal_use_search
 msgid "Case"
 msgstr "Type"
@@ -103,9 +104,10 @@ msgstr "Créé le"
 
 #. module: stock_internal_use_of_products
 #: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use__date_done
+#: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use_line__date_done
 #: model_terms:ir.ui.view,arch_db:stock_internal_use_of_products.view_internal_use_search
 msgid "Date"
-msgstr "Date"
+msgstr "Date "
 
 #. module: stock_internal_use_of_products
 #: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use__description
@@ -141,9 +143,9 @@ msgid "Expense Account"
 msgstr "Compte de dépenses"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use.py:252
-#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:188
-#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:206
+#: code:addons/stock_internal_use_of_products/models/internal_use.py:258
+#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:242
+#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:261
 #, python-format
 msgid "Expense Transfert (%s)"
 msgstr "Transfert de charge (%s)"
@@ -181,7 +183,7 @@ msgid "ID"
 msgstr ""
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use_case.py:61
+#: code:addons/stock_internal_use_of_products/models/internal_use_case.py:77
 #, python-format
 msgid "Incorrect Accounting Settings.\n"
 "Account and Journal should be set both or not set."
@@ -206,10 +208,16 @@ msgid "Internal Use Cases"
 msgstr "Types d'utilisation interne"
 
 #. module: stock_internal_use_of_products
+#: model:ir.actions.act_window,name:stock_internal_use_of_products.action_internal_use_line_tree
+#: model:ir.ui.menu,name:stock_internal_use_of_products.menu_internal_use_line
+msgid "Internal Use Lines"
+msgstr "Lignes d'utilisation interne"
+
+#. module: stock_internal_use_of_products
 #: model:ir.actions.act_window,name:stock_internal_use_of_products.action_internal_use_tree
 #: model:ir.model,name:stock_internal_use_of_products.model_internal_use
 #: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use_line__internal_use_id
-#: model:ir.ui.menu,name:stock_internal_use_of_products.menu_internal_uses
+#: model:ir.ui.menu,name:stock_internal_use_of_products.menu_internal_use
 msgid "Internal Uses"
 msgstr "Utilisations interne"
 
@@ -243,7 +251,7 @@ msgid "Last Updated on"
 msgstr "Dernière mise à jour le"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:77
+#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:113
 #, python-format
 msgid "Line quantity can not be null"
 msgstr "La quantité sur la ligne ne peut pas être nulle"
@@ -304,6 +312,7 @@ msgstr "Définir le journal comptable utilisé pour générer les écritures com
 
 #. module: stock_internal_use_of_products
 #: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use__state
+#: model:ir.model.fields,field_description:stock_internal_use_of_products.field_internal_use_line__state
 #: model_terms:ir.ui.view,arch_db:stock_internal_use_of_products.view_internal_use_search
 msgid "Status"
 msgstr "État"
@@ -330,13 +339,13 @@ msgid "Stock Settings"
 msgstr "Paramètres de stock"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:87
+#: code:addons/stock_internal_use_of_products/models/internal_use_line.py:123
 #, python-format
 msgid "The current unit of measure '%s' of the line %s (quantity  %s) is not compatible with the unit of measure '%s' of the product"
 msgstr "L'unité de mesure '%s' de la ligne %s (quantité  %s) n'est pas compatible avec l'unité de mesure '%s' de l'article"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/product_product.py:27
+#: code:addons/stock_internal_use_of_products/models/product_product.py:28
 #, python-format
 msgid "The product %s has not account expense defined. Please define one and try again"
 msgstr "Le produit %s n'a pas de compte de dépenses défini. Veuillez en définir un et réessayer"
@@ -352,6 +361,7 @@ msgid "To Process"
 msgstr "A traiter"
 
 #. module: stock_internal_use_of_products
+#: model_terms:ir.ui.view,arch_db:stock_internal_use_of_products.view_internal_use_line_tree
 #: model_terms:ir.ui.view,arch_db:stock_internal_use_of_products.view_internal_use_tree
 msgid "Total"
 msgstr ""
@@ -383,13 +393,13 @@ msgid "Wizard to confirm several internal uses"
 msgstr "Assistant pour confirmer plusieurs utilisations internes"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use.py:110
+#: code:addons/stock_internal_use_of_products/models/internal_use.py:117
 #, python-format
 msgid "You can not confirm an empty Internal Use."
 msgstr "Vous ne pouvez pas valider une utilisation interne sans aucune ligne"
 
 #. module: stock_internal_use_of_products
-#: code:addons/stock_internal_use_of_products/models/internal_use.py:91
+#: code:addons/stock_internal_use_of_products/models/internal_use.py:98
 #, python-format
 msgid "You can only delete draft uses."
 msgstr "Vous pouvez seulement supprimer les utilisations internes en brouillon"

--- a/stock_internal_use_of_products/models/internal_use.py
+++ b/stock_internal_use_of_products/models/internal_use.py
@@ -8,17 +8,17 @@ import time
 from odoo import _, api, fields, models
 from odoo.exceptions import Warning as UserError
 
+_INTERNAL_USE_STATE = [
+    ("draft", "New"),
+    ("confirmed", "Confirmed"),
+    ("done", "Done"),
+]
+
 
 class InternalUse(models.Model):
     _name = "internal.use"
     _description = "Internal Uses"
     _order = "date_done desc, name"
-
-    _INTERNAL_USE_STATE = [
-        ("draft", "New"),
-        ("confirmed", "Confirmed"),
-        ("done", "Done"),
-    ]
 
     # Columns section
     name = fields.Char(string="Name", required=True, default="Draft internal use")

--- a/stock_internal_use_of_products/models/internal_use_line.py
+++ b/stock_internal_use_of_products/models/internal_use_line.py
@@ -7,6 +7,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import Warning as UserError
 
 import odoo.addons.decimal_precision as dp
+from .internal_use import _INTERNAL_USE_STATE
 
 
 class InternalUseLine(models.Model):
@@ -20,6 +21,22 @@ class InternalUseLine(models.Model):
         index=True,
         readonly=True,
         ondelete="cascade",
+    )
+
+    internal_use_case_id = fields.Many2one(
+        comodel_name="internal.use.case",
+        string="Case",
+        related="internal_use_id.internal_use_case_id", store=True
+    )
+
+    state = fields.Selection(
+        selection=_INTERNAL_USE_STATE, string="Status",
+        related="internal_use_id.state", store=True
+    )
+
+    date_done = fields.Date(
+        string="Date",
+        related="internal_use_id.date_done", store=True
     )
 
     product_id = fields.Many2one(

--- a/stock_internal_use_of_products/views/view_internal_use.xml
+++ b/stock_internal_use_of_products/views/view_internal_use.xml
@@ -118,7 +118,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="context">{'search_default_to_confirm': 1}</field>
     </record>
 
-    <menuitem id="menu_internal_uses"
+    <menuitem id="menu_internal_use"
         name="Internal Uses"
         parent="stock.menu_stock_warehouse_mgmt"
         sequence="50"

--- a/stock_internal_use_of_products/views/view_internal_use_line.xml
+++ b/stock_internal_use_of_products/views/view_internal_use_line.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (C) 2021 - Today: GRAP (http://www.grap.coop)
+@author: Sylvain LE GAL (https://twitter.com/legalsylvain)
+License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+-->
+<odoo>
+
+    <record id="view_internal_use_line_search" model="ir.ui.view">
+        <field name="model">internal.use.line</field>
+        <field name="arch" type="xml">
+            <search>
+                <field name="internal_use_case_id"/>
+                <field name="internal_use_id"/>
+                <field name="product_id"/>
+                <field name="date_done"/>
+            </search>
+
+        </field>
+    </record>
+
+    <record id="view_internal_use_line_tree" model="ir.ui.view">
+        <field name="model">internal.use.line</field>
+        <field name="arch" type="xml">
+            <tree decoration-primary="state=='draft'" decoration-success="state=='confirmed'" create="false">
+                <field name="internal_use_id"/>
+                <field name="date_done"/>
+                <field name="product_id"/>
+                <field name="product_qty"/>
+                <field name="product_uom_id"/>
+                <field name="price_unit"/>
+                <field name="amount" sum="Total"/>
+                <field name="state"/>
+                <field name="company_id" groups="base.group_multi_company"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="action_internal_use_line_tree" model="ir.actions.act_window">
+        <field name="name">Internal Use Lines</field>
+        <field name="res_model">internal.use.line</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree</field>
+    </record>
+
+    <menuitem id="menu_internal_use_line"
+        name="Internal Use Lines"
+        parent="stock.menu_stock_warehouse_mgmt"
+        sequence="51"
+        action="action_internal_use_line_tree"/>
+
+</odoo>


### PR DESCRIPTION
ajoute une entrée de menu pour les lignes d'utilisation internes pour faciliter des exports en Excel.


Ref : apps/deck/#/board/144/card/1681
