### PR TITLE
12.0 Fix "stock_inventory_merge"

### DIFF
--- a/stock_inventory_merge/models/stock_inventory.py
+++ b/stock_inventory_merge/models/stock_inventory.py
@@ -109,13 +109,17 @@ class StockInventory(models.Model):
                                 uom_obj.browse(default_uom_id),
                             )
 
-                # Update the first line with the sumed quantity
-                keeped_line = line_obj.browse(keeped_line_id)
-                keeped_line.write({"product_qty": sum_quantity})
-
                 # Delete all the other lines
                 line_ids.remove(keeped_line_id)
                 line_obj.browse(line_ids).unlink()
+
+                # Update the first line with the sumed quantity
+                # Note: This has to be done *after* deleting the other lines,
+                # because the `write()` calls the `_check_no_duplicate_line()`
+                # which may trigger the "You cannot have two inventory
+                # adjustments..." exception.
+                keeped_line = line_obj.browse(keeped_line_id)
+                keeped_line.write({"product_qty": sum_quantity})
 
     # Custom Section
     @api.multi

--- a/stock_inventory_merge/models/stock_inventory.py
+++ b/stock_inventory_merge/models/stock_inventory.py
@@ -78,7 +78,7 @@ class StockInventory(models.Model):
                 if not found:
                     # Add the line, if inventory line was not found
                     product_line["product_qty"] = 0
-                    product_line["inventory_id"] = self.id
+                    product_line["inventory_id"] = inventory.id
                     line_obj.create(product_line)
 
     @api.multi

--- a/stock_inventory_merge/models/stock_inventory.py
+++ b/stock_inventory_merge/models/stock_inventory.py
@@ -74,7 +74,7 @@ class StockInventory(models.Model):
                         item
                     ) == self._get_inventory_line_keys(product_line):
                         found = True
-                        continue
+                        break
                 if not found:
                     # Add the line, if inventory line was not found
                     product_line["product_qty"] = 0


### PR DESCRIPTION
This branch contains three small fixes for module "stock_inventory_merge" in version 12.0:

* break from a loop
   using `break` instead of `continue`
  ... which will continue the loop, which is unnecessary in this case
* assign new "Complete With Zero" lines to current inventory
  using the `inventory.id` of the single inventory in the `for inventory in self` loop
  ... instead of `self.id`, which will work only for singleton browse record sets
* prevent "You cannot have two inventory adjustments..." error
  by switching the order of updating the kept line and removing all its other duplicates
  ... In action `action_merge_duplicated_line()` of button "Merge Duplicates", the duplicate lines need to be deleted *before* writing the total quantity on the kept line, as the write method checks for duplicates, which may trigger that "You cannot have two inventory adjustments..." exception; see Odoo core https://github.com/odoo/odoo/blob/6b24df0e037d64be0d4e48045e47215059bffddb/addons/stock/models/stock_inventory.py#L406. Note that ironically this button method is intended to merge duplicate lines, for the purpose of *preventing* that exception.
