### PR TITLE
[IMP] Add option to cancel merged source inventories

### DIFF
--- a/stock_inventory_merge/views/view_wizard_stock_inventory_merge.xml
+++ b/stock_inventory_merge/views/view_wizard_stock_inventory_merge.xml
@@ -10,8 +10,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <field name="model">wizard.stock.inventory.merge</field>
         <field name="arch" type="xml">
             <form>
-                <group col="4">
-                    <field name="name"/>
+                <group>
+                    <group>
+                        <field name="name"/>
+                        <field name="cancel_src" />
+                    </group>
                 </group>
                 <footer>
                     <button name="action_merge" string="Merge Inventories" type="object" class="oe_highlight"/>


### PR DESCRIPTION
For module "stock_inventory_merge" in version 12.0, this branch adds the option to cancel the merged source inventories.

The "Merge Inventories" wizard will have a checkbox "Cancel source inventories?" When checked, the source inventories will get into state `"cancel"` during the merge.

Note that the Odoo core method `action_cancel_draft()` sets the stock.inventory to state `"draft"` and deletes the inventory lines:
https://github.com/odoo/odoo/blob/6b24df0e037d64be0d4e48045e47215059bffddb/addons/stock/models/stock_inventory.py#L209-L214
But instead, we want to have state `"draft"` and keep the lines.
