### PR TITLE
[FIX] product_print_category: Use different report container to make barcodes show up

### DIFF
--- a/product_print_category/report/report_pricetag.xml
+++ b/product_print_category/report/report_pricetag.xml
@@ -8,7 +8,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 <odoo>
 
     <template id="report_pricetag">
-        <t t-call="web.html_container">
+        <t t-call="web.basic_layout">
             <t t-foreach="categories_data" t-as="category_data">
                 <div class="page">
                     <t t-call="#{ category_data['print_category'].qweb_view_id.xml_id }" />


### PR DESCRIPTION
I am facing the issue described here:
https://www.odoo.com/forum/help-1/cannot-print-barcodes-on-pdf-reports-149885

In short: the barcodes do not show up. Not sure what the issue is, but
part of the fix is calling `web.basic_layout` instead of
`web.html_container` in the report template. I don't know why this
helps, but it does.