### PR TITLE
[FIX] name_search_reset_res_partner : search by display name

### DIFF
--- a/name_search_reset_res_partner/demo/res_partner.xml
+++ b/name_search_reset_res_partner/demo/res_partner.xml
@@ -6,10 +6,15 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 <odoo>
 
-    <record id="name_search_partner" model="res.partner">
-        <field name="name">Name Search Reset Partner</field>
+    <record id="parent_partner" model="res.partner">
+        <field name="name">Name Search Reset Partner Parent</field>
         <field name="vat">987987987</field>
         <field name="email">mail@res_partner.fr</field>
+    </record>
+
+    <record id="child_partner" model="res.partner">
+        <field name="name">My Child</field>
+        <field name="parent_id" ref="name_search_reset_res_partner.parent_partner"/>
     </record>
 
 </odoo>

--- a/name_search_reset_res_partner/models/res_partner.py
+++ b/name_search_reset_res_partner/models/res_partner.py
@@ -12,7 +12,7 @@ class ResPartner(models.Model):
 
     @api.model
     def _get_name_search_reset_fields(self):
-        return ["name", "email"]
+        return ["display_name", "email"]
 
     @api.model
     def _name_search(

--- a/name_search_reset_res_partner/tests/test_module.py
+++ b/name_search_reset_res_partner/tests/test_module.py
@@ -11,6 +11,10 @@ class TestModule(TransactionCase):
     def setUp(self):
         super().setUp()
         self.ResPartner = self.env["res.partner"]
+        self.parent_partner = self.env.ref(
+            "name_search_reset_res_partner.parent_partner"
+        )
+        self.child_partner = self.env.ref("name_search_reset_res_partner.child_partner")
 
     # Test Section
     def test_01_name_search_by_vat(self):
@@ -22,9 +26,17 @@ class TestModule(TransactionCase):
         )
 
     def test_02_name_search_by_name(self):
-        search_qty = len(self.ResPartner.name_search("Search Reset"))
-        self.assertNotEqual(
-            search_qty,
-            0,
-            "Name search should be based on name field.",
+        found_ids = [
+            x[0] for x in self.ResPartner.name_search(self.parent_partner.name)
+        ]
+        self.assertIn(
+            self.parent_partner.id,
+            found_ids,
+            "Name search should be based on name field, and return parent partner.",
+        )
+        self.assertIn(
+            self.child_partner.id,
+            found_ids,
+            "Name search should be based on Complete Name field,"
+            " and return child partner.",
         )


### PR DESCRIPTION
search by ``display_name`` and not by ``name`` on ``res.partner``.

[GRAP-Task-437](https://erp.grap.coop/web#id=437&action=2148&active_id=3&model=project.task&view_type=form&menu_id=1673)