### PR TITLE
[FIX] product_print_category: Set the correct group for pricetags user

### DIFF
--- a/product_print_category/security/ir.model.access.csv
+++ b/product_print_category/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
-ir_model_access_product_print_category_user,Print Category User,product_print_category.model_product_print_category,base.group_user,1,,,
+ir_model_access_product_print_category_user,Print Category User,product_print_category.model_product_print_category,product_print_category.user,1,0,0,0
 ir_model_access_product_print_category_manager,Print Category Manager,product_print_category.model_product_print_category,product_print_category.manager,1,1,1,1


### PR DESCRIPTION
Found this while working on #146. The group was wrongly set to base.group_user.

Added the 0s for clarity's sake.