### PR TITLE
[FIX] product_print_category: use key instead of xml_id

### DIFF
--- a/product_print_category/readme/newsfragments/1.bugfix.rst
+++ b/product_print_category/readme/newsfragments/1.bugfix.rst
@@ -1,0 +1,3 @@
+Use the `key` instead of the `xml_id` to find qweb template for the
+pricetag. It let user create their own template via the Odoo interface,
+because such template does not have `xml_id`.

--- a/product_print_category/report/report_pricetag.xml
+++ b/product_print_category/report/report_pricetag.xml
@@ -11,7 +11,7 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
         <t t-call="web.html_container">
             <t t-foreach="categories_data" t-as="category_data">
                 <div class="page">
-                    <t t-call="#{ category_data['print_category'].qweb_view_id.xml_id }" />
+                    <t t-call="#{ category_data['print_category'].qweb_view_id.key }" />
                 </div>
             </t>
         </t>


### PR DESCRIPTION
Use the `key` instead of the `xml_id` to find qweb template for the pricetag. This let user create their own template via the Odoo interface, because such template does not have `xml_id`.

Step to reproduce:

1. Create a new qweb template in Odoo via the menu Settings > Technical > User Interface > View. And put xml content to print a customised pricetag.
2. Create a `product.print.category` and refer to the previously created qweb template.

Intended behaviour:
Pricetag can be generated using the new qweb template

Occurring:
Error when generating template saying that template `''` is not found.

Issue:
The problem comes from the fact that qweb template created in the Odoo interface has no `xml_id` as they do not comes from a file in a module.

Fix:
Using the field `key` instead of the field `xml_id` fix this.

[coopiteasy task](https://gestion.coopiteasy.be/web#id=9268&action=479&model=project.task&view_type=form&menu_id=536)