### PR TITLE
[FIX] product_print_category: Make print_category_id searchable on product template

### DIFF
--- a/product_print_category/models/product_template.py
+++ b/product_print_category/models/product_template.py
@@ -10,7 +10,7 @@ class ProductTemplate(models.Model):
     _inherit = ["product.template", "product.print.category.mixin"]
 
     print_category_id = fields.Many2one(
-        related="product_variant_id.print_category_id", readonly=False
+        related="product_variant_id.print_category_id", readonly=False, store=True
     )
 
     to_print = fields.Boolean(related="product_variant_id.to_print", readonly=False)


### PR DESCRIPTION
By storing print_category_id, we can search on it.

Internal task: https://gestion.coopiteasy.be/web#id=9605&model=project.task&view_type=form&menu_id=