### PR TITLE
No update on Products Print Format paper format

### DIFF
--- a/product_print_category/data/report_paperformat.xml
+++ b/product_print_category/data/report_paperformat.xml
@@ -5,7 +5,7 @@ Copyright (C) 2016-Today: La Louve (<http://www.lalouve.net/>)
 License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 -->
 
-<odoo>
+<odoo noupdate="1">
 
         <record id="paper_format" model="report.paperformat">
             <field name="name">Products Print Format</field>


### PR DESCRIPTION
Some users want to customize the paper format. With the `noupdate` option, their customizations will be persistent.