### PR TITLE
[12.0][FIX] fix product.template related fields

### DIFF
--- a/product_print_category/models/product_template.py
+++ b/product_print_category/models/product_template.py
@@ -9,6 +9,9 @@ class ProductTemplate(models.Model):
     _name = "product.template"
     _inherit = ["product.template", "product.print.category.mixin"]
 
+    # store this field (required for the related fields below)
+    product_variant_id = fields.Many2one(store=True)
+
     print_category_id = fields.Many2one(
         related="product_variant_id.print_category_id", readonly=False
     )

--- a/product_print_category/models/product_template.py
+++ b/product_print_category/models/product_template.py
@@ -18,6 +18,30 @@ class ProductTemplate(models.Model):
 
     to_print = fields.Boolean(related="product_variant_id.to_print", readonly=False)
 
+    @api.depends("product_variant_ids")
+    def _compute_product_variant_id(self):
+        # This is a very particular workaround for the following workflow:
+        #
+        # - Archive product.template.
+        # - Duplicate product.template. <-- This method is called in this step.
+        # - Unarchive duplicated product.template.
+        #
+        # If a product.template is archived, then its variants are also
+        # archived. This means that accessing `product_variant_ids` outputs an
+        # empty recordset, subsequently causing this compute function to wrongly
+        # populate `product_variant_id` with null. By disabling `active_test`,
+        # we prevent this problem.
+        #
+        # Upsteam bugfix in <https://github.com/odoo/odoo/pull/181811> targeted
+        # at v15+.
+        for p in self:
+            # We do with_context() on each individual product instead of on
+            # self, because doing it on self does not produce the desired result
+            # in Odoo 12, somehow.
+            p.product_variant_id = (
+                p.with_context(active_test=False).product_variant_ids[:1].id
+            )
+
     @api.multi
     def write(self, vals):
         res = super().write(vals)

--- a/product_print_category/models/product_template.py
+++ b/product_print_category/models/product_template.py
@@ -18,33 +18,14 @@ class ProductTemplate(models.Model):
 
     to_print = fields.Boolean(related="product_variant_id.to_print", readonly=False)
 
-    @api.depends("product_variant_ids")
-    def _compute_product_variant_id(self):
-        # This is a very particular workaround for the following workflow:
-        #
-        # - Archive product.template.
-        # - Duplicate product.template. <-- This method is called in this step.
-        # - Unarchive duplicated product.template.
-        #
-        # If a product.template is archived, then its variants are also
-        # archived. This means that accessing `product_variant_ids` outputs an
-        # empty recordset, subsequently causing this compute function to wrongly
-        # populate `product_variant_id` with null. By disabling `active_test`,
-        # we prevent this problem.
-        #
-        # Upsteam bugfix in <https://github.com/odoo/odoo/pull/181811> targeted
-        # at v15+.
-        for p in self:
-            # We do with_context() on each individual product instead of on
-            # self, because doing it on self does not produce the desired result
-            # in Odoo 12, somehow.
-            p.product_variant_id = (
-                p.with_context(active_test=False).product_variant_ids[:1].id
-            )
-
     @api.multi
     def write(self, vals):
         res = super().write(vals)
         if self.env.context.get("update_to_print_category", True):
             self._update_to_print_values(vals)
+        # Recompute product_variant_id to circumvent a bug where
+        # product_variant_ids cannot be accessed normally (empty recordset)
+        # because they are archived at time of computation.
+        if "active" in vals:
+            self._compute_product_variant_id()
         return res

--- a/product_print_category/models/product_template.py
+++ b/product_print_category/models/product_template.py
@@ -18,14 +18,15 @@ class ProductTemplate(models.Model):
 
     to_print = fields.Boolean(related="product_variant_id.to_print", readonly=False)
 
+    # Recompute when active is changed, too. If the variants are inactive, the
+    # template's product_variant_id is empty.
+    @api.depends("product_variant_ids", "product_variant_ids.active")
+    def _compute_product_variant_id(self):
+        return super()._compute_product_variant_id()
+
     @api.multi
     def write(self, vals):
         res = super().write(vals)
         if self.env.context.get("update_to_print_category", True):
             self._update_to_print_values(vals)
-        # Recompute product_variant_id to circumvent a bug where
-        # product_variant_ids cannot be accessed normally (empty recordset)
-        # because they are archived at time of computation.
-        if "active" in vals:
-            self._compute_product_variant_id()
         return res

--- a/product_print_category/tests/__init__.py
+++ b/product_print_category/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_product_print_category
+from . import test_product_template

--- a/product_print_category/tests/test_product_template.py
+++ b/product_print_category/tests/test_product_template.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2024 Coop IT Easy SC
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from odoo.tests.common import SavepointCase
+
+
+class TestProductTemplate(SavepointCase):
+    def test_product_variant_id(self):
+        """Test that product_variant_id is correctly populated for cloned
+        archived products.
+        """
+        product = self.env["product.template"].create({"name": "Test"})
+        product.active = False
+        new_product = product.copy()
+        new_variants = new_product.with_context(active_test=False).product_variant_ids
+        self.assertFalse(new_product.active)
+        self.assertEqual(new_product.product_variant_id, new_variants[0])
+        new_product.active = True
+        self.assertEqual(new_product.product_variant_id, new_variants[0])

--- a/product_print_category/tests/test_product_template.py
+++ b/product_print_category/tests/test_product_template.py
@@ -9,12 +9,17 @@ class TestProductTemplate(SavepointCase):
     def test_product_variant_id(self):
         """Test that product_variant_id is correctly populated for cloned
         archived products.
+
+        This test is needed because we now store the product_variant_id computed
+        field, instead of recomputing it every time.
         """
         product = self.env["product.template"].create({"name": "Test"})
         product.active = False
         new_product = product.copy()
         new_variants = new_product.with_context(active_test=False).product_variant_ids
         self.assertFalse(new_product.active)
-        self.assertEqual(new_product.product_variant_id, new_variants[0])
+        # This one is weird. The default Odoo upstream behaviour is that this
+        # field is False when the template is inactive. We replicate that.
+        self.assertFalse(new_product.product_variant_id)
         new_product.active = True
         self.assertEqual(new_product.product_variant_id, new_variants[0])


### PR DESCRIPTION
make `product.template.product_variant_id` a stored computed field to avoid the following error when setting the `print_category_id` or `to_print` related fields:

> non-stored field product.template.product_variant_id cannot be searched.