### PR TITLE
[FIX] l10n_fr_account_move_partner_required_fields: Overload more generic function.

### DIFF
--- a/l10n_fr_account_move_partner_required_fields/models/account_move.py
+++ b/l10n_fr_account_move_partner_required_fields/models/account_move.py
@@ -38,7 +38,7 @@ class AccountMove(models.Model):
             # Check SIREN
             move.partner_has_siren = bool(partner.siren)
 
-    def action_post(self):
+    def _post(self, *args, **kwargs):
         # Override posting if it lacks some required informations
         for move in self:
             partner = move.partner_id
@@ -62,4 +62,4 @@ class AccountMove(models.Model):
                     )
                 )
 
-        return super().action_post()
+        return super()._post(*args, **kwargs)


### PR DESCRIPTION


Rational : point_of_sale module, when generating invoice, doesn't call action_post() but just _post(). As a result, blocking invoicing is not possible in point of sale. (and maybe in other places,...) This patch should fix that point.
Ref : https://github.com/odoo/odoo/blob/16.0/addons/point_of_sale/models/pos_order.py#L863