### PR TITLE
[16.0][FIX] user_limited_access_settings for sudo call

### DIFF
--- a/user_limited_access_settings/i18n/fr.po
+++ b/user_limited_access_settings/i18n/fr.po
@@ -1,0 +1,72 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#   * user_limited_access_settings
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-06-09 13:17+0000\n"
+"PO-Revision-Date: 2026-06-09 13:17+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: user_limited_access_settings
+#: model:ir.model,name:user_limited_access_settings.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: user_limited_access_settings
+#: model:res.groups,name:user_limited_access_settings.group_limited_settings
+msgid "Limited Settings"
+msgstr "Paramétrage limité"
+
+#. module: user_limited_access_settings
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_users__role_line_ids
+msgid "Role lines"
+msgstr "Lignes du rôle"
+
+#. module: user_limited_access_settings
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_users__role_ids
+msgid "Roles"
+msgstr "Rôles"
+
+#. module: user_limited_access_settings
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_partner__signup_expiration
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_users__signup_expiration
+msgid "Signup Expiration"
+msgstr "Expiration de la session de connexion"
+
+#. module: user_limited_access_settings
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_partner__signup_token
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_users__signup_token
+msgid "Signup Token"
+msgstr "Jeton de connexion"
+
+#. module: user_limited_access_settings
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_partner__signup_type
+#: model:ir.model.fields,field_description:user_limited_access_settings.field_res_users__signup_type
+msgid "Signup Token Type"
+msgstr "Type de jeton de connexion"
+
+#. module: user_limited_access_settings
+#. odoo-python
+#: code:addons/user_limited_access_settings/models/res_users.py:0
+#, python-format
+msgid ""
+"The user '%(username)s' lack some rights to do this action. \n"
+"Here are the groups needed :\n"
+"- %(group_names)s"
+msgstr ""
+"L'utilisateur·rice '%(username)s' manque de certains droits d'accès pour effectuer cette action. \n"
+"Voici les groupes manquants :\n"
+"- %(group_names)s"
+
+#. module: user_limited_access_settings
+#: model:ir.model,name:user_limited_access_settings.model_res_users
+msgid "User"
+msgstr "Utilisateur·rice"

--- a/user_limited_access_settings/models/res_users.py
+++ b/user_limited_access_settings/models/res_users.py
@@ -18,7 +18,8 @@ class ResUsers(models.Model):
 
     @api.constrains("groups_id")
     def _check_escalation(self):
-        if self.env.user._is_admin():
+        # ignore constrains for sudo() call
+        if self.env.is_admin():
             return
         missing_groups = self.env["res.groups"]
         allowed_groups = (
@@ -31,13 +32,13 @@ class ResUsers(models.Model):
             if group not in allowed_groups:
                 missing_groups |= group
 
-            if missing_groups:
-                raise ValidationError(
-                    _(
-                        "You can set the group '%(group_names)s'"
-                        " to users, because you are not member of those groups.",
-                        group_names=" , ".join(
-                            [x.display_name for x in missing_groups]
-                        ),
-                    )
+        if missing_groups:
+            raise ValidationError(
+                _(
+                    "The user '%(username)s' lack some rights to"
+                    " do this action. \n"
+                    "Here are the groups needed :\n- %(group_names)s",
+                    username=str(self.env.user.name),
+                    group_names="\n- ".join([x.display_name for x in missing_groups]),
                 )
+            )

--- a/user_limited_access_settings/tests/test_module.py
+++ b/user_limited_access_settings/tests/test_module.py
@@ -12,9 +12,6 @@ class TestModule(TransactionCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.demo_user = cls.env.ref("user_limited_access_settings.user_demo")
-        cls.limited_group = cls.env.ref(
-            "user_limited_access_settings.group_limited_settings"
-        )
         cls.random_group = cls.env.ref("base.group_private_addresses")
         cls.user_vals = {
             "name": "User 1",
@@ -22,6 +19,7 @@ class TestModule(TransactionCase):
             "groups_id": [Command.set(cls.random_group.ids)],
         }
 
+    # Can't create user with groups which it's not part of
     def test_access_escalation_forbidden(self):
         with self.assertRaises(ValidationError):
             self.env["res.users"].with_user(self.demo_user).create(self.user_vals)


### PR DESCRIPTION
Bug relevé avec le blocage pour fusionner deux contacts, la fonction `_merge` dans `base_partner_merge.py`  :
[Ici sur Odoo](https://github.com/odoo/odoo/blob/16.0/odoo/addons/base/wizard/base_partner_merge.py#L310)
```
        # Make the company of all related users consistent with destination partner company
        if dst_partner.company_id:
            partner_ids.mapped('user_ids').sudo().write({
                'company_ids': [Command.link(dst_partner.company_id.id)],
                'company_id': dst_partner.company_id.id
            })
```

Cela déclenchae `_check_escalation(self):` avec sudo et l'algorythme comparait les groupes d'utilisateur normal (genre LTG) avec les droits de sudo (donc tous les groupes)

Aussi Pti décalage après boucle du code pour avoir l'ensemble de la liste manquante, comme ceci : 

<img width="753" height="629" alt="Capture d’écran du 2026-06-09 14-39-53" src="https://github.com/user-attachments/assets/24e71c1b-1118-4453-b5b9-7b5dc4db0074" />
 