### PR TITLE
[16.0][FIX] hr_expense_vat_incl_improved readonly force save

### DIFF
--- a/hr_expense_vat_incl_improved/views/view_hr_expense.xml
+++ b/hr_expense_vat_incl_improved/views/view_hr_expense.xml
@@ -36,6 +36,11 @@ License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
             <field name="total_amount" position="attributes">
                 <attribute name="attrs">{'readonly': ['|', ('sheet_is_editable', '=', False), ('product_has_cost', '=', True)]}</attribute>
             </field>
+            <!-- Force save is needed with new readonly state otherwise it doesn't save value -->
+            <field name="total_amount" position="attributes">
+                <attribute name="force_save">1</attribute>
+            </field>
+
 
             <!-- Make total_amount_company label always hidden if currency are the sames -->
             <xpath expr="//label[@for='total_amount_company']" position="attributes">


### PR DESCRIPTION
[Ticket interne](https://erp.grap.coop/web#id=3708&action=2148&active_id=30&model=project.task&view_type=form&menu_id=1673)

Avec un produit qui a un coût, l'enregistrement remettait tout à 0, par manque d'un pti force_save vu qu'il y a un nvo readonly dans la vue